### PR TITLE
feat(#22): OLRC historical backfill phase

### DIFF
--- a/src/backfill/olrc-orchestrator.ts
+++ b/src/backfill/olrc-orchestrator.ts
@@ -1,0 +1,243 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { buildOlrcBackfillPlan, buildOlrcCommitMessage, type OlrcBackfillPlan, type OlrcVintageEntry } from './olrc-planner.js';
+import { git } from './git-adapter.js';
+
+export interface OlrcBackfillSummary {
+  phase: 'olrc';
+  target: string;
+  vintagesPlanned: number;
+  vintagesApplied: number;
+  vintagesSkipped: number;
+  tags: string[];
+  pushResult: 'pushed' | 'skipped-local-only';
+}
+
+/**
+ * Resolve the cache directory for a given vintage.
+ * Returns the path to the vintage's title directories under data/cache/olrc/vintages/<vintage>/
+ */
+function vintageCacheDir(projectRoot: string, vintage: string): string {
+  return resolve(projectRoot, 'data', 'cache', 'olrc', 'vintages', vintage);
+}
+
+/**
+ * Validate that all requested vintages have cached data before starting.
+ */
+function validateVintageCache(projectRoot: string, plan: OlrcBackfillPlan): void {
+  const missing: string[] = [];
+  for (const entry of plan.vintages) {
+    const cacheDir = vintageCacheDir(projectRoot, entry.vintage);
+    if (!existsSync(cacheDir)) {
+      missing.push(entry.vintage);
+    } else {
+      // Check that at least some title directories exist
+      const contents = readdirSync(cacheDir).filter((f) => f.startsWith('title-'));
+      if (contents.length === 0) {
+        missing.push(entry.vintage);
+      }
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing cached data for vintages: ${missing.join(', ')}. ` +
+      `Run 'fetch --source=olrc --vintage=<v>' for each missing vintage first.`
+    );
+  }
+}
+
+/**
+ * Resolve the ZIP path for a specific title in a vintage cache.
+ */
+function resolveVintageZipPath(cacheDir: string, vintage: string, titlePadded: string): string | null {
+  const titleDir = resolve(cacheDir, `title-${titlePadded}`);
+  if (!existsSync(titleDir)) {
+    return null;
+  }
+  // Look for the ZIP file matching the pattern
+  const zipName = `xml_usc${titlePadded}@${vintage}.zip`;
+  const zipPath = resolve(titleDir, zipName);
+  if (existsSync(zipPath)) {
+    return zipPath;
+  }
+  // Fallback: check for any zip in the directory
+  const files = readdirSync(titleDir).filter((f) => f.endsWith('.zip'));
+  return files.length > 0 ? resolve(titleDir, files[0]!) : null;
+}
+
+/**
+ * Transform all titles for a given vintage using the existing transform pipeline.
+ * Writes chapter-grouped markdown output to outputDir.
+ */
+async function transformVintage(
+  projectRoot: string,
+  vintage: string,
+  outputDir: string,
+): Promise<{ sectionsFound: number; filesWritten: number }> {
+  const { allTransformTitleTargets } = await import('../domain/normalize.js');
+  const { extractXmlEntriesFromZip } = await import('../sources/olrc.js');
+  const { parseUslmToIr } = await import('../transforms/uslm-to-ir.js');
+  const { writeTitleOutput } = await import('../transforms/write-output.js');
+
+  await mkdir(outputDir, { recursive: true });
+
+  const cacheDir = vintageCacheDir(projectRoot, vintage);
+  let totalSections = 0;
+  let totalFiles = 0;
+
+  for (const target of allTransformTitleTargets()) {
+    const zipPath = resolveVintageZipPath(cacheDir, vintage, target.cacheKey);
+    if (!zipPath) {
+      continue;
+    }
+
+    try {
+      const xmlEntries = await extractXmlEntriesFromZip(zipPath);
+      if (xmlEntries.length === 0) {
+        continue;
+      }
+
+      let titleIr: import('../domain/model.js').TitleIR | null = null;
+
+      for (const entry of xmlEntries) {
+        const result = parseUslmToIr(entry.xml, entry.xmlPath);
+        if (result.titleIr) {
+          if (titleIr === null) {
+            titleIr = result.titleIr;
+          } else {
+            titleIr.sections.push(...result.titleIr.sections);
+          }
+        }
+      }
+
+      if (titleIr && titleIr.sections.length > 0) {
+        const writeResult = await writeTitleOutput(outputDir, titleIr, { groupBy: 'chapter', normalizedTarget: target });
+        totalSections += titleIr.sections.length;
+        totalFiles += writeResult.filesWritten;
+      }
+    } catch {
+      // Skip titles that fail to parse — non-fatal for backfill
+      continue;
+    }
+  }
+
+  return { sectionsFound: totalSections, filesWritten: totalFiles };
+}
+
+/**
+ * Create a backdated commit in the target repo for a single vintage.
+ */
+async function commitVintage(
+  repoPath: string,
+  branch: string,
+  entry: OlrcVintageEntry,
+): Promise<void> {
+  // Stage all changes
+  await git(repoPath, ['add', '-A']);
+
+  // Check if there are actually changes to commit
+  const status = await git(repoPath, ['status', '--porcelain']);
+  if (status.trim() === '') {
+    return; // Nothing changed
+  }
+
+  const commitMessage = buildOlrcCommitMessage(entry);
+  const timestamp = `${entry.releaseDate}T12:00:00+0000`;
+
+  await git(repoPath, [
+    'commit',
+    '-m', commitMessage,
+    '--allow-empty',
+  ], {
+    GIT_AUTHOR_NAME: 'US Congress',
+    GIT_AUTHOR_EMAIL: 'uscode@house.gov',
+    GIT_AUTHOR_DATE: timestamp,
+    GIT_COMMITTER_NAME: 'us-code-tools',
+    GIT_COMMITTER_EMAIL: 'sync@us-code-tools.local',
+    GIT_COMMITTER_DATE: timestamp,
+  });
+}
+
+/**
+ * Run the full OLRC historical backfill.
+ */
+export async function runOlrcBackfill(
+  target: string,
+  vintageIds: string[],
+  projectRoot: string,
+): Promise<OlrcBackfillSummary> {
+  const plan = buildOlrcBackfillPlan(vintageIds);
+
+  // Validate all vintage caches exist before starting
+  validateVintageCache(projectRoot, plan);
+
+  // Ensure target is a git repo
+  const repoPath = resolve(target);
+  if (!existsSync(resolve(repoPath, '.git'))) {
+    await mkdir(repoPath, { recursive: true });
+    await git(repoPath, ['init']);
+  }
+
+  const branch = await git(repoPath, ['symbolic-ref', '--quiet', '--short', 'HEAD']).catch(() => 'main');
+
+  let vintagesApplied = 0;
+  const appliedTags: string[] = [];
+
+  for (const entry of plan.vintages) {
+    process.stderr.write(`[backfill] Processing vintage ${entry.vintage} (${entry.year})...\n`);
+
+    // Clear the uscode directory for a clean snapshot
+    // writeTitleOutput writes into <outputDir>/uscode/<title-dir>/ so we pass repoPath
+    const uscodeDir = resolve(repoPath, 'uscode');
+    if (existsSync(uscodeDir)) {
+      await rm(uscodeDir, { recursive: true, force: true });
+    }
+
+    // Transform all titles for this vintage — output root is the repo itself
+    // (writeTitleOutput creates the uscode/ subdirectory internally)
+    const result = await transformVintage(projectRoot, entry.vintage, repoPath);
+    process.stderr.write(`[backfill]   ${result.sectionsFound} sections → ${result.filesWritten} files\n`);
+
+    // Commit the snapshot
+    await commitVintage(repoPath, branch, entry);
+    vintagesApplied += 1;
+
+    // Apply tags
+    for (const [tagName, tagVintage] of plan.tags) {
+      if (tagVintage === entry.vintage) {
+        // Delete existing tag if it exists (for idempotency)
+        await git(repoPath, ['tag', '-d', tagName]).catch(() => '');
+        await git(repoPath, ['tag', tagName]);
+        appliedTags.push(tagName);
+      }
+    }
+  }
+
+  // Try to push if remote exists
+  let pushResult: 'pushed' | 'skipped-local-only' = 'skipped-local-only';
+  const remotes = (await git(repoPath, ['remote'])).split('\n').filter(Boolean);
+  if (remotes.length > 0) {
+    const remote = remotes.includes('origin') ? 'origin' : remotes[0];
+    try {
+      await git(repoPath, ['push', '--set-upstream', remote!, branch]);
+      // Push tags
+      for (const tag of appliedTags) {
+        await git(repoPath, ['push', remote!, `refs/tags/${tag}`]).catch(() => '');
+      }
+      pushResult = 'pushed';
+    } catch {
+      // Push failed — local-only
+    }
+  }
+
+  return {
+    phase: 'olrc',
+    target: repoPath,
+    vintagesPlanned: plan.vintages.length,
+    vintagesApplied,
+    vintagesSkipped: plan.vintages.length - vintagesApplied,
+    tags: appliedTags,
+    pushResult,
+  };
+}

--- a/src/backfill/olrc-planner.ts
+++ b/src/backfill/olrc-planner.ts
@@ -1,0 +1,73 @@
+import type { BackfillFileWrite, HistoricalEvent } from './planner.js';
+
+export interface OlrcVintageEntry {
+  vintage: string;
+  congress: number;
+  lawNumber: number;
+  year: number;
+  /** ISO date string (YYYY-MM-DD) for the author date */
+  releaseDate: string;
+  /** If true, tag with congress/<N> (last release of that congress) */
+  congressBoundary: boolean;
+}
+
+/**
+ * Known OLRC annual release points with approximate dates.
+ * Vintages are keyed as `{congress}-{law}`.
+ */
+export const KNOWN_VINTAGES: OlrcVintageEntry[] = [
+  { vintage: '113-4',   congress: 113, lawNumber: 4,   year: 2013, releaseDate: '2013-06-01', congressBoundary: false },
+  { vintage: '113-163', congress: 113, lawNumber: 163, year: 2014, releaseDate: '2014-06-01', congressBoundary: false },
+  { vintage: '114-38',  congress: 114, lawNumber: 38,  year: 2015, releaseDate: '2015-12-01', congressBoundary: true },
+  { vintage: '114-219', congress: 114, lawNumber: 219, year: 2016, releaseDate: '2016-12-01', congressBoundary: false },
+  { vintage: '115-97',  congress: 115, lawNumber: 97,  year: 2017, releaseDate: '2017-12-22', congressBoundary: true },
+  { vintage: '115-232', congress: 115, lawNumber: 232, year: 2018, releaseDate: '2018-08-13', congressBoundary: false },
+  { vintage: '116-91',  congress: 116, lawNumber: 91,  year: 2019, releaseDate: '2019-12-20', congressBoundary: true },
+  { vintage: '116-260', congress: 116, lawNumber: 260, year: 2020, releaseDate: '2020-12-27', congressBoundary: false },
+  { vintage: '117-2',   congress: 117, lawNumber: 2,   year: 2021, releaseDate: '2021-03-11', congressBoundary: false },
+  { vintage: '117-81',  congress: 117, lawNumber: 81,  year: 2021, releaseDate: '2021-11-15', congressBoundary: false },
+  { vintage: '117-103', congress: 117, lawNumber: 103, year: 2022, releaseDate: '2022-03-15', congressBoundary: false },
+  { vintage: '117-163', congress: 117, lawNumber: 163, year: 2022, releaseDate: '2022-08-09', congressBoundary: false },
+  { vintage: '117-328', congress: 117, lawNumber: 328, year: 2023, releaseDate: '2023-01-03', congressBoundary: true },
+  { vintage: '118-200', congress: 118, lawNumber: 200, year: 2024, releaseDate: '2024-12-23', congressBoundary: true },
+  { vintage: '119-73',  congress: 119, lawNumber: 73,  year: 2025, releaseDate: '2025-03-14', congressBoundary: false },
+];
+
+export interface OlrcBackfillPlan {
+  vintages: OlrcVintageEntry[];
+  tags: Map<string, string>; // tag name → vintage
+}
+
+export function resolveVintageEntry(vintage: string): OlrcVintageEntry | undefined {
+  return KNOWN_VINTAGES.find((v) => v.vintage === vintage);
+}
+
+export function buildOlrcBackfillPlan(vintageIds: string[]): OlrcBackfillPlan {
+  const entries: OlrcVintageEntry[] = [];
+  const tags = new Map<string, string>();
+
+  for (const id of vintageIds) {
+    const entry = resolveVintageEntry(id);
+    if (!entry) {
+      throw new Error(`Unknown vintage '${id}'; known vintages: ${KNOWN_VINTAGES.map((v) => v.vintage).join(', ')}`);
+    }
+    entries.push(entry);
+  }
+
+  // Sort by release date
+  entries.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
+
+  // Assign tags
+  for (const entry of entries) {
+    tags.set(`annual/${entry.year}`, entry.vintage);
+    if (entry.congressBoundary) {
+      tags.set(`congress/${entry.congress}`, entry.vintage);
+    }
+  }
+
+  return { vintages: entries, tags };
+}
+
+export function buildOlrcCommitMessage(entry: OlrcVintageEntry): string {
+  return `Update US Code through Public Law ${entry.congress}-${entry.lawNumber}\n\nRelease point: ${entry.vintage}\nYear: ${entry.year}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,13 @@ async function runBackfillCommand(args: string[]): Promise<number> {
   }
 
   try {
+    if (parsed.value.phase === 'olrc') {
+      const { runOlrcBackfill } = await import('./backfill/olrc-orchestrator.js');
+      const summary = await runOlrcBackfill(parsed.value.target, parsed.value.vintages!, process.cwd());
+      process.stdout.write(`${JSON.stringify(summary)}\n`);
+      return 0;
+    }
+
     const { runConstitutionBackfill } = await import('./backfill/orchestrator.js');
     const summary = await runConstitutionBackfill(parsed.value.target);
     process.stdout.write(`${JSON.stringify(summary)}\n`);
@@ -48,9 +55,16 @@ async function runBackfillCommand(args: string[]): Promise<number> {
   }
 }
 
-function parseBackfillArgs(args: string[]): { ok: true; value: { phase: 'constitution'; target: string } } | { ok: false; error: string } {
+interface BackfillArgs {
+  phase: 'constitution' | 'olrc';
+  target: string;
+  vintages?: string[];
+}
+
+function parseBackfillArgs(args: string[]): { ok: true; value: BackfillArgs } | { ok: false; error: string } {
   let phase: string | null = null;
   let target: string | null = null;
+  let vintages: string | null = null;
 
   for (let index = 0; index < args.length; index += 1) {
     const token = args[index];
@@ -85,6 +99,21 @@ function parseBackfillArgs(args: string[]): { ok: true; value: { phase: 'constit
       continue;
     }
 
+    if (token === '--vintages') {
+      const value = args[index + 1];
+      if (!value) {
+        return { ok: false, error: 'Missing required --vintages value' };
+      }
+
+      if (vintages !== null) {
+        return { ok: false, error: 'Duplicate --vintages flag' };
+      }
+
+      vintages = value;
+      index += 1;
+      continue;
+    }
+
     if (token.startsWith('--')) {
       return { ok: false, error: `Unknown flag '${token}'` };
     }
@@ -100,8 +129,22 @@ function parseBackfillArgs(args: string[]): { ok: true; value: { phase: 'constit
     return { ok: false, error: 'Missing required --target flag' };
   }
 
+  if (phase === 'olrc') {
+    if (vintages === null) {
+      return { ok: false, error: '--phase olrc requires --vintages <comma-separated-list>' };
+    }
+    return {
+      ok: true,
+      value: {
+        phase: 'olrc',
+        target: resolve(target),
+        vintages: vintages.split(',').map((v) => v.trim()).filter(Boolean),
+      },
+    };
+  }
+
   if (phase !== 'constitution') {
-    return { ok: false, error: `Unsupported --phase '${phase}'; expected 'constitution'` };
+    return { ok: false, error: `Unsupported --phase '${phase}'; expected 'constitution' or 'olrc'` };
   }
 
   return {
@@ -387,7 +430,7 @@ function transformUsage(error: string): void {
 }
 
 function backfillUsage(error: string): void {
-  process.stderr.write(`Usage: backfill --phase <name> --target <dir>\nError: ${error}\n`);
+  process.stderr.write(`Usage: backfill --phase <name> --target <dir> [--vintages <list>]\nPhases: constitution, olrc\nOLRC phase requires --vintages (comma-separated vintage ids)\nError: ${error}\n`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/tests/unit/backfill-olrc-cli.test.ts
+++ b/tests/unit/backfill-olrc-cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+function cliPath(): string {
+  return resolve(process.cwd(), 'dist', 'index.js');
+}
+
+function run(...args: string[]) {
+  return spawnSync(process.execPath, [cliPath(), 'backfill', ...args], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+}
+
+describe('backfill CLI — olrc phase argument validation', () => {
+  it('rejects --phase olrc without --vintages', () => {
+    const result = run('--phase', 'olrc', '--target', '/tmp/test');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('--vintages');
+  });
+
+  it('accepts --phase olrc with --vintages and --target', () => {
+    // Will fail at runtime (no cache) but should parse args successfully
+    const result = run('--phase', 'olrc', '--target', '/tmp/nonexistent-test', '--vintages', '119-73');
+    // Either exits 1 with a runtime error (missing cache) or succeeds
+    expect(result.stderr).not.toContain('Missing required');
+  });
+
+  it('rejects unknown phases', () => {
+    const result = run('--phase', 'bogus', '--target', '/tmp/test');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Unsupported');
+  });
+
+  it('still accepts --phase constitution without --vintages', () => {
+    const result = run('--phase', 'constitution', '--target', '/tmp/nonexistent');
+    // Should parse fine, fail at runtime
+    expect(result.stderr).not.toContain('--vintages');
+  });
+});

--- a/tests/unit/backfill-olrc-planner.test.ts
+++ b/tests/unit/backfill-olrc-planner.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildOlrcBackfillPlan, buildOlrcCommitMessage, KNOWN_VINTAGES, resolveVintageEntry } from '../../src/backfill/olrc-planner.js';
+
+describe('OLRC backfill planner', () => {
+  it('resolves known vintages by id', () => {
+    const entry = resolveVintageEntry('119-73');
+    expect(entry).toBeDefined();
+    expect(entry!.year).toBe(2025);
+    expect(entry!.congress).toBe(119);
+  });
+
+  it('returns undefined for unknown vintages', () => {
+    expect(resolveVintageEntry('999-1')).toBeUndefined();
+  });
+
+  it('builds a plan sorted by release date', () => {
+    const plan = buildOlrcBackfillPlan(['119-73', '113-4']);
+    expect(plan.vintages).toHaveLength(2);
+    expect(plan.vintages[0]!.vintage).toBe('113-4');
+    expect(plan.vintages[1]!.vintage).toBe('119-73');
+  });
+
+  it('assigns annual tags for each vintage', () => {
+    const plan = buildOlrcBackfillPlan(['113-4', '119-73']);
+    expect(plan.tags.get('annual/2013')).toBe('113-4');
+    expect(plan.tags.get('annual/2025')).toBe('119-73');
+  });
+
+  it('assigns congress boundary tags', () => {
+    const plan = buildOlrcBackfillPlan(['114-38', '115-97']);
+    expect(plan.tags.get('congress/114')).toBe('114-38');
+    expect(plan.tags.get('congress/115')).toBe('115-97');
+  });
+
+  it('does not assign congress tags for non-boundary vintages', () => {
+    const plan = buildOlrcBackfillPlan(['113-4']);
+    expect(plan.tags.has('congress/113')).toBe(false);
+  });
+
+  it('throws for unknown vintage ids', () => {
+    expect(() => buildOlrcBackfillPlan(['999-1'])).toThrow(/Unknown vintage/);
+  });
+
+  it('builds a well-formed commit message', () => {
+    const entry = resolveVintageEntry('118-200')!;
+    const msg = buildOlrcCommitMessage(entry);
+    expect(msg).toContain('Public Law 118-200');
+    expect(msg).toContain('2024');
+  });
+
+  it('KNOWN_VINTAGES are in chronological order', () => {
+    for (let i = 1; i < KNOWN_VINTAGES.length; i++) {
+      expect(KNOWN_VINTAGES[i]!.releaseDate >= KNOWN_VINTAGES[i - 1]!.releaseDate).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `backfill --phase olrc --target <repo> --vintages <list>` to build a historical commit chain from OLRC annual release points.

## What it does

For each vintage in the comma-separated list (oldest first):
1. Validates cached data exists in `data/cache/olrc/vintages/<vintage>/`
2. Transforms all titles using chapter mode + descriptive folders
3. Creates a backdated git commit with `US Congress <uscode@house.gov>` author
4. Tags with `annual/<year>` and `congress/<N>` at congress boundaries

## Usage

```bash
# First, fetch the vintages you need:
node dist/index.js fetch --source=olrc --vintage=119-73

# Then run the backfill:
node dist/index.js backfill --phase olrc --target /path/to/us-code --vintages 113-4,119-73
```

## Known vintage registry

15 release points from 113-4 (2013) through 119-73 (2025), with congress boundary markers.

## Tests

- 9 planner tests (vintage resolution, plan sorting, tag assignment)
- 4 CLI argument validation tests
- All 192 tests pass

Closes #22