### PR TITLE
feat(#22): add run-backfill.sh — per-vintage process isolation

### DIFF
--- a/scripts/run-backfill.sh
+++ b/scripts/run-backfill.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# run-backfill.sh — Run OLRC backfill one vintage at a time to avoid OOM.
+#
+# Each vintage runs in its own Node process so the heap is freed between runs.
+# Resume-safe: the orchestrator skips already-committed vintages.
+#
+# Usage: ./scripts/run-backfill.sh <target-repo>
+set -euo pipefail
+
+TARGET="${1:?Usage: run-backfill.sh <target-repo>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VINTAGES=(
+  113-21
+  113-296
+  114-38
+  114-329
+  115-51
+  115-442
+  116-91
+  116-344
+  117-81
+  117-262
+  118-82
+  118-158
+  119-73
+)
+
+TOTAL=${#VINTAGES[@]}
+ACCUMULATED=""
+
+echo "=== OLRC Backfill: $TOTAL vintages → $TARGET ==="
+echo ""
+
+for i in "${!VINTAGES[@]}"; do
+  v="${VINTAGES[$i]}"
+  n=$((i + 1))
+
+  # Accumulate vintages so the planner builds the full plan each time
+  # (needed for correct tag assignment)
+  if [ -z "$ACCUMULATED" ]; then
+    ACCUMULATED="$v"
+  else
+    ACCUMULATED="$ACCUMULATED,$v"
+  fi
+
+  echo "────────────────────────────────────────"
+  echo "[$n/$TOTAL] Vintage $v"
+  echo "────────────────────────────────────────"
+
+  # Run in a separate process with generous heap (8GB)
+  # The orchestrator's resume logic will skip already-committed vintages
+  if node --max-old-space-size=8192 "$PROJECT_ROOT/dist/index.js" backfill \
+    --phase olrc --target "$TARGET" --vintages "$ACCUMULATED" 2>&1; then
+    echo "  ✓ done"
+  else
+    echo "  ✗ FAILED (exit code $?)"
+    echo "  Re-run this script to resume from where it stopped."
+    exit 1
+  fi
+
+  echo ""
+done
+
+echo "=== All $TOTAL vintages committed ==="
+echo ""
+echo "Inspect with:"
+echo "  cd $TARGET"
+echo "  git log --oneline --decorate"
+echo "  git tag -l"
+echo "  git diff annual/2013..annual/2025 --stat"


### PR DESCRIPTION
## What

Adds `scripts/run-backfill.sh` — a wrapper that runs the OLRC backfill one vintage at a time in separate Node processes.

## Why

The monolithic backfill OOM'd at vintage 4/13 (~4GB heap exhaustion). The XML parser + transformer holds entire titles in memory and doesn't release between vintages within a single process.

## How it works

- Each vintage gets its own `node --max-old-space-size=8192` process
- Accumulates the vintage list so the planner builds the full plan (correct tag assignment)
- Resume-safe: the orchestrator's `detectAppliedVintages()` skips already-committed vintages
- If a vintage fails, exits with instructions to re-run

## Testing

- Ran against `/tmp/us-code-backfill` — resumed from vintage 4 after OOM crash, currently processing remaining 10 vintages successfully.

Closes: N/A (enhancement to #22)